### PR TITLE
Fix strptime pattern

### DIFF
--- a/txt2csv_intervals.py
+++ b/txt2csv_intervals.py
@@ -19,7 +19,7 @@ def convert(inputFile, outputFile):
    			continue
    			
 		try:
-			timeStamp = datetime.datetime.strptime(line, "%A, %B %j, %Y %H:%M:%S %p %Z").time().strftime('%H:%M:%S')
+			timeStamp = datetime.datetime.strptime(line, "%A, %B %j, %Y %I:%M:%S %p %Z").time().strftime('%H:%M:%S')
 			headerLine = True
 		except:
 			out_txt.writerow(line.split()+[timeStamp])


### PR DESCRIPTION
Hi, I found your project by searching for "strptime," "%H," and "%p" on GitHub. Changing %H to %I as detailed in this pull request will fix time parsing, as using "%H" with 12-hour times will ignore AM/PM and always give you the AM equivalent, even when %p is in the format string. I was bit by the same issue earlier today. Hope this helps!
